### PR TITLE
Dropped the Core collision checks

### DIFF
--- a/onbreakplaceblock.lua
+++ b/onbreakplaceblock.lua
@@ -9,7 +9,7 @@ function OnPlayerPlacingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, CursorX
 	if not (Player:HasPermission("core.build")) then
 		return true
 	else
-		if not (Player:HasPermission("core.spawnprotect.bypass")) and not (PROTECTRADIUS == 0) then
+		if not (Player:HasPermission("core.spawnprotect.bypass")) and (PROTECTRADIUS ~= 0) then
 			local World = Player:GetWorld()
 			local xcoord = World:GetSpawnX()
 			local ycoord = World:GetSpawnY()
@@ -30,52 +30,6 @@ function OnPlayerPlacingBlock(Player, BlockX, BlockY, BlockZ, BlockFace, CursorX
 			WarnPlayer(Player)
 
 			return true
-		else
-			if BlockType == "50" or BlockType == "76" then
-				local X = BlockX
-				local Y = BlockY
-				local Z = BlockZ
-				X, Y, Z = AddFaceDirection(X, Y, Z, BlockFace)
-				if (Y >= 256 or Y < 0) then
-					return true
-				end
-			
-				local CheckCollision = function(Player)
-					-- drop the decimals, we only care about the full block X,Y,Z
-					local PlayerX = math.floor(Player:GetPosX(), 0)
-					local PlayerY = math.floor(Player:GetPosY(), 0)
-					local PlayerZ = math.floor(Player:GetPosZ(), 0)
-										
-					local collision = false
-					if ((BlockFace == BLOCK_FACE_TOP) and (PlayerY == BlockY - 2) and (PlayerX == BlockX) and (PlayerZ == BlockZ)) then
-						collision = true
-					end
-					
-					if ((BlockFace == BLOCK_FACE_BOTTOM) and (PlayerY == BlockY + 1) and (PlayerX == BlockX) and (PlayerZ == BlockZ)) then
-						collision = true
-					end
-					
-					if ((BlockFace == BLOCK_FACE_NORTH) and (PlayerX == BlockX) and (PlayerZ == BlockZ - 1)) then
-						if ((PlayerY == BlockY) or (PlayerY + 1 == BlockY)) then collision = true end
-					end
-					
-					if ((BlockFace == BLOCK_FACE_SOUTH) and (PlayerX == BlockX) and (PlayerZ == BlockZ + 1)) then
-						if ((PlayerY == BlockY) or (PlayerY + 1 == BlockY)) then collision = true end
-					end
-					
-					if ((BlockFace == BLOCK_FACE_WEST) and (PlayerX == BlockX - 1) and (PlayerZ == BlockZ)) then
-						if ((PlayerY == BlockY) or (PlayerY + 1 == BlockY)) then collision = true end
-					end
-				
-					if ((BlockFace == BLOCK_FACE_EAST) and (PlayerX == BlockX + 1) and (PlayerZ == BlockZ)) then
-						if ((PlayerY == BlockY) or (PlayerY + 1 == BlockY)) then collision = true end
-					end		
-					return collision
-				end
-				if (Player:GetWorld():ForEachPlayer(CheckCollision) == false) then
-					return true
-				end
-			end
 		end
 	end
 	return false


### PR DESCRIPTION
- Fixes MCServer bug #188 & FS #188
- Made a variable check more readable

The Core collision checks were doing nada. Players could still place block over another with server lag. The server should really do this, and not Core.
