### PR TITLE
Fixed Portal and Worlds commands.

### DIFF
--- a/portal-worlds.lua
+++ b/portal-worlds.lua
@@ -25,8 +25,7 @@ function HandleWorldsCommand(Split, Player)
 	local NumWorlds = 0
 	local Worlds = {}
 	cRoot:Get():ForEachWorld(function(World)
-		NumWorlds = NumWorlds + 1
-		Worlds[NumWorlds] = World:GetName()
+		table.insert(Worlds, World:GetName())
 	end)
 
 	SendMessage(Player, "There are " .. NumWorlds .. " worlds:")


### PR DESCRIPTION
`/portal` now accepts zero parameters, returns the current world name in such a case
`/worlds` reports the current world name as the last output line.
Fixed the code for better Lua performance (avoid needless table-counting)
