### PR TITLE
Add spectator as a default gamemode in webadmin server settings.

### DIFF
--- a/web_serversettings.lua
+++ b/web_serversettings.lua
@@ -222,6 +222,7 @@ local function HTML_Select_GameMode(Name, DefaultValue)
 		.. HTML_Option("0", "Survival", DefaultValue == 0)
 		.. HTML_Option("1", "Creative",  DefaultValue == 1)
 		.. HTML_Option("2", "Adventure",  DefaultValue == 2)
+		.. HTML_Option("3", "Spectator",  DefaultValue == 3)
 		.. [[</select>]]
 end
 


### PR DESCRIPTION
Spectator is missing in the world management options of server settings, this corrects that. However, MCServer currently doesn't correctly handle spectator mode as a default gamemode and instead changes it to adventure mode. Therefore this pull request depends upon pull request mc-server/MCServer#1645 being accepted before it will be useful.
