### PR TITLE
Fix plugin version inconsistency

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -6,7 +6,7 @@
 g_PluginInfo = 
 {
 	Name = "Core",
-	Version = "14",
+	Version = "15",
 	Date = "2014-06-11",
 	SourceLocation = "https://github.com/cuberite/Core",
 	Description = [[Implements some of the basic commands needed to run a simple server.]],

--- a/main.lua
+++ b/main.lua
@@ -28,7 +28,7 @@ lastsender = {}
 -- Called by Cuberite on plugin start to initialize the plugin
 function Initialize(Plugin)
 	Plugin:SetName( "Core" )
-	Plugin:SetVersion( 15 )
+	Plugin:SetVersion( g_PluginInfo["Version"] )
 
 	-- Register for all hooks needed
 	cPluginManager:AddHook(cPluginManager.HOOK_CHAT,                  OnChat)


### PR DESCRIPTION
The plugin's Info.lua said version 14, but when the plugin actually loaded it logged version 15:

```
Initialised Core v.15
```

because Plugin:SetVersion was called with a hardcoded value of "15". Is 15 the intended version, not 14? If so, to resolve this inconsistency, changed the SetVersion call to use the g_PluginInfo version, avoiding having the version number in two places (where they can, and did, differ).