### PR TITLE
Add /op and /deop commands

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -243,6 +243,20 @@ g_PluginInfo =
 			HelpString = "Shows or sets a player's rank.",
 		},
 
+		["/op"] =
+		{
+			Permission = "core.rank",
+			Handler = HandleOpCommand,
+			HelpString = "Add a player to the Admin rank.",
+		},
+
+		["/deop"] =
+		{
+			Permission = "core.rank",
+			Handler = HandleDeOpCommand,
+			HelpString = "Add a player to the Default rank.",
+		},
+
 		["/regen"] =
 		{
 			Permission = "core.regen",
@@ -753,6 +767,20 @@ g_PluginInfo =
 		{
 			Handler =  HandleConsoleRank,
 			HelpString = "Shows or sets a player's rank.",
+		},
+
+		["op"] =
+		{
+			Permission = "core.rank",
+			Handler = HandleConsoleOp,
+			HelpString = "Add a player to the Admin rank.",
+		},
+
+		["deop"] =
+		{
+			Permission = "core.rank",
+			Handler = HandleConsoleDeOp,
+			HelpString = "Add a player to the Default rank.",
 		},
 		
 		["regen"] =

--- a/Info.lua
+++ b/Info.lua
@@ -247,14 +247,14 @@ g_PluginInfo =
 		{
 			Permission = "core.rank",
 			Handler = HandleOpCommand,
-			HelpString = "Add a player to the Admin rank.",
+			HelpString = "Add a player to the administrator rank.",
 		},
 
 		["/deop"] =
 		{
 			Permission = "core.rank",
 			Handler = HandleDeOpCommand,
-			HelpString = "Add a player to the Default rank.",
+			HelpString = "Add a player to the default rank.",
 		},
 
 		["/regen"] =

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Implements some of the basic commands needed to run a simple server.
 | ------- | ---------- | ----------- |
 |/ban | core.ban | Bans a player.|
 |/clear | core.clear | Clears the inventory of a player.|
+|/deop | core.rank | Add a player to the Default rank.|
 |/difficulty | core.difficulty | Changes the difficulty level of the world you're located in.|
 |/do | core.do | Runs a command as a player.|
 |/effect | core.effect | Adds an effect to a player.|
@@ -22,6 +23,7 @@ Implements some of the basic commands needed to run a simple server.
 |/listranks | core.listranks | Shows a list of the available ranks.|
 |/me | core.me | Broadcasts what you are doing.|
 |/motd | core.motd | Shows the message of the day.|
+|/op | core.rank | Add a player to the Operator rank. |
 |/plugins | core.plugins | Shows a list of the plugins.|
 |/portal | core.portal | Moves your player to a different world.|
 |/r | core.tell | Replies to the latest private message you recieved.|
@@ -82,7 +84,7 @@ Implements some of the basic commands needed to run a simple server.
 | core.motd |  | `/motd` |  |
 | core.plugins |  | `/plugins` |  |
 | core.portal |  | `/portal` |  |
-| core.rank |  | `/rank` |  |
+| core.rank |  | `/rank`, `/op`, `/deop` |  |
 | core.regen |  | `/regen` |  |
 | core.reload |  | `/reload` |  |
 | core.save-all |  | `/save-all` |  |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implements some of the basic commands needed to run a simple server.
 | ------- | ---------- | ----------- |
 |/ban | core.ban | Bans a player.|
 |/clear | core.clear | Clears the inventory of a player.|
-|/deop | core.rank | Add a player to the Default rank.|
+|/deop | core.rank | Add a player to the default rank.|
 |/difficulty | core.difficulty | Changes the difficulty level of the world you're located in.|
 |/do | core.do | Runs a command as a player.|
 |/effect | core.effect | Adds an effect to a player.|
@@ -23,7 +23,7 @@ Implements some of the basic commands needed to run a simple server.
 |/listranks | core.listranks | Shows a list of the available ranks.|
 |/me | core.me | Broadcasts what you are doing.|
 |/motd | core.motd | Shows the message of the day.|
-|/op | core.rank | Add a player to the Operator rank. |
+|/op | core.rank | Add a player to the administrator rank. |
 |/plugins | core.plugins | Shows a list of the plugins.|
 |/portal | core.portal | Moves your player to a different world.|
 |/r | core.tell | Replies to the latest private message you recieved.|

--- a/console.lua
+++ b/console.lua
@@ -314,24 +314,11 @@ function HandleConsoleOp(a_Split)
 	end
 
 	local PlayerName = a_Split[2]
-
-	local AdminRank
-	local Ranks = cRankManager:GetAllRanks()
-	for _, Rank in ipairs(Ranks) do
-		local Permissions = cRankManager:GetRankPermissions(Rank)
-		for _, Permission in ipairs(Permissions) do
-			if Permission == "*" then
-				AdminRank = Rank
-				break
-			end
-		end
-		if AdminRank then
-			break
-		end
-	end
+	local AdminRank = GetAdminRank()
 
 	if not AdminRank then
-		return true, "No admin rank found, missing * permission"
+		SendMessage(a_Player, "No admin rank found, missing * permission")
+		return true
 	end
 
 	return HandleConsoleRank({"rank", PlayerName, AdminRank})

--- a/console.lua
+++ b/console.lua
@@ -306,6 +306,38 @@ end
 
 
 
+function HandleConsoleOp(a_Split)
+	-- Check the params:
+	if ((a_Split[2] == nil) or (a_Split[3] ~= nil)) then
+		-- Not enough or too many parameters
+		return true, "Usage: " .. a_Split[1] .. " <player>"
+	end
+
+	local PlayerName = a_Split[2]
+
+	return HandleConsoleRank({"rank", PlayerName, "Admin"})
+end
+
+
+
+
+
+function HandleConsoleDeOp(a_Split)
+	-- Check the params:
+	if ((a_Split[2] == nil) or (a_Split[3] ~= nil)) then
+		-- Not enough or too many parameters
+		return true, "Usage: " .. a_Split[1] .. " <player>"
+	end
+
+	local PlayerName = a_Split[2]
+
+	return HandleConsoleRank({"rank", PlayerName, "Default"})
+end
+
+
+
+
+
 function HandleConsoleSaveAll(Split)
 	cRoot:Get():SaveAllChunks()
 	return true

--- a/console.lua
+++ b/console.lua
@@ -330,8 +330,9 @@ function HandleConsoleDeOp(a_Split)
 	end
 
 	local PlayerName = a_Split[2]
+	local DefaultRank = cRankManager:GetDefaultRank()
 
-	return HandleConsoleRank({"rank", PlayerName, "Default"})
+	return HandleConsoleRank({"rank", PlayerName, DefaultRank})
 end
 
 

--- a/console.lua
+++ b/console.lua
@@ -315,7 +315,26 @@ function HandleConsoleOp(a_Split)
 
 	local PlayerName = a_Split[2]
 
-	return HandleConsoleRank({"rank", PlayerName, "Admin"})
+	local AdminRank
+	local Ranks = cRankManager:GetAllRanks()
+	for _, Rank in ipairs(Ranks) do
+		local Permissions = cRankManager:GetRankPermissions(Rank)
+		for _, Permission in ipairs(Permissions) do
+			if Permission == "*" then
+				AdminRank = Rank
+				break
+			end
+		end
+		if AdminRank then
+			break
+		end
+	end
+
+	if not AdminRank then
+		return true, "No admin rank found, missing * permission"
+	end
+
+	return HandleConsoleRank({"rank", PlayerName, AdminRank})
 end
 
 

--- a/functions.lua
+++ b/functions.lua
@@ -182,3 +182,17 @@ function GetWorld( WorldName, Player )
 		return World
 	end
 end
+
+
+function GetAdminRank()
+	local AdminRank
+	local Ranks = cRankManager:GetAllRanks()
+	for _, Rank in ipairs(Ranks) do
+		local Permissions = cRankManager:GetRankPermissions(Rank)
+		for _, Permission in ipairs(Permissions) do
+			if Permission == "*" then
+				return Rank
+			end
+		end
+	end
+end

--- a/ranks.lua
+++ b/ranks.lua
@@ -75,3 +75,33 @@ end
 
 
 
+function HandleOpCommand(a_Split, a_Player)
+	-- Check the params:
+	if ((a_Split[2] == nil) or (a_Split[3] ~= nil)) then
+		-- Too many or too few parameters, print the usage:
+		SendMessage(a_Player, "Usage: " .. a_Split[1] .. " <player>")
+		return true
+	end
+
+	local PlayerName = a_Split[2]
+
+	return HandleRankCommand({"rank", PlayerName, "Admin"}, a_Player)
+end
+
+
+
+
+
+function HandleDeOpCommand(a_Split, a_Player)
+	-- Check the params:
+	if ((a_Split[2] == nil) or (a_Split[3] ~= nil)) then
+		-- Too many or too few parameters, print the usage:
+		SendMessage(a_Player, "Usage: " .. a_Split[1] .. " <player>")
+		return true
+	end
+
+	local PlayerName = a_Split[2]
+
+	return HandleRankCommand({"rank", PlayerName, "Default"}, a_Player)
+end
+

--- a/ranks.lua
+++ b/ranks.lua
@@ -84,27 +84,12 @@ function HandleOpCommand(a_Split, a_Player)
 	end
 
 	local PlayerName = a_Split[2]
-
-	local AdminRank
-	local Ranks = cRankManager:GetAllRanks()
-	for _, Rank in ipairs(Ranks) do
-		local Permissions = cRankManager:GetRankPermissions(Rank)
-		for _, Permission in ipairs(Permissions) do
-			if Permission == "*" then
-				AdminRank = Rank
-				break
-			end
-		end
-		if AdminRank then
-			break
-		end
-	end
+	local AdminRank = GetAdminRank()
 
 	if not AdminRank then
 		SendMessage(a_Player, "No admin rank found, missing * permission")
 		return true
 	end
-
 
 	return HandleRankCommand({"rank", PlayerName, AdminRank}, a_Player)
 end

--- a/ranks.lua
+++ b/ranks.lua
@@ -101,7 +101,8 @@ function HandleDeOpCommand(a_Split, a_Player)
 	end
 
 	local PlayerName = a_Split[2]
+	local DefaultRank = cRankManager:GetDefaultRank()
 
-	return HandleRankCommand({"rank", PlayerName, "Default"}, a_Player)
+	return HandleRankCommand({"rank", PlayerName, DefaultRank}, a_Player)
 end
 

--- a/ranks.lua
+++ b/ranks.lua
@@ -85,7 +85,28 @@ function HandleOpCommand(a_Split, a_Player)
 
 	local PlayerName = a_Split[2]
 
-	return HandleRankCommand({"rank", PlayerName, "Admin"}, a_Player)
+	local AdminRank
+	local Ranks = cRankManager:GetAllRanks()
+	for _, Rank in ipairs(Ranks) do
+		local Permissions = cRankManager:GetRankPermissions(Rank)
+		for _, Permission in ipairs(Permissions) do
+			if Permission == "*" then
+				AdminRank = Rank
+				break
+			end
+		end
+		if AdminRank then
+			break
+		end
+	end
+
+	if not AdminRank then
+		SendMessage(a_Player, "No admin rank found, missing * permission")
+		return true
+	end
+
+
+	return HandleRankCommand({"rank", PlayerName, AdminRank}, a_Player)
 end
 
 


### PR DESCRIPTION
Adds two simple convenient commands, /op to add a player to Admin rank, and /deop to add to Default rank.

These commands just call out to /rank, which can already be used for this purpose, but /op and /deop are more intuitive. The lack of /op was confusing for myself when first starting to use Cuberite, and not only me: https://github.com/cuberite/cuberite/issues/3684 https://github.com/cuberite/cuberite/issues/1835 it is also in the FAQ: 

https://forum.cuberite.org/thread-1596.html

> Q: How can I make myself operator?
> A: You can use the rank <playername>...

but https://github.com/cuberite/Core/issues/158 notes a caveat, the Operator rank does not have full privileges, by "opping" a player the admin likely intends to add to the Admin rank instead. This pull request implements the suggestion:

> Example: To get Operator in Cuberite you need to execute /rank [player] Admin(Note that the Operator rank has not the full permissions!), but most players are familar with /op [player]. So the /op command should be defined as a shortcut to the /rank ... Admin command.

