### PR TITLE
Added gamerule command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.deuser
 @EnableMobDebug.lua
 forum_info.txt
+!EnableMobDebug.lua

--- a/Info.lua
+++ b/Info.lua
@@ -715,6 +715,24 @@ g_PluginInfo =
 			},
 		},
 
+		
+		["gamerule"]=
+		{
+			Handler = HandleConsoleGameRule,
+			HelpString = "Sets or queries a game rule value.",
+			ParameterCombinations =
+			{
+				{
+					Params = "rule",
+					Help = "Queries a game rule value",
+				},
+				{
+					Params = "rule value",
+					Help = "Sets a game rule value",
+				},
+			},
+		},
+
 		["give"] =
 		{
 			Handler =  HandleConsoleGive,
@@ -1111,6 +1129,12 @@ g_PluginInfo =
 		["core.enchant.self"] =
 		{
 			Description = "Allows players to add an enchantment to their own held item.",
+			RecommendedGroups = "admins",
+		},
+
+		["core.gamerule"] =
+		{
+			Description = "Allows players to set and query game rule values",
 			RecommendedGroups = "admins",
 		},
 

--- a/Info.lua
+++ b/Info.lua
@@ -6,7 +6,7 @@
 g_PluginInfo = 
 {
 	Name = "Core",
-	Version = "15",
+	Version = "16",
 	Date = "2014-06-11",
 	SourceLocation = "https://github.com/cuberite/Core",
 	Description = [[Implements some of the basic commands needed to run a simple server.]],
@@ -107,6 +107,24 @@ g_PluginInfo =
 				{
 					Params = "gamemode player",
 					Help = "Changes the gamemode of the specified player, rather then your own.",
+				},
+			},
+		},
+
+		["/gamerule"] =
+		{
+			Permission = "core.gamerule",
+			Handler = HandleGameRuleCommand,
+			HelpString = "Sets or queries a game rule value.",
+			ParameterCombinations =
+			{
+				{
+					Params = "rule",
+					Help = "Queries a game rule value",
+				},
+				{
+					Params = "rule value",
+					Help = "Sets a game rule value",
 				},
 			},
 		},

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Implements some of the basic commands needed to run a simple server.
 | core.effect |  | `/effect` |  |
 | core.enchant | Allows players to add an enchantment to a player's held item. | `/enchant` | admins |
 | core.enchant.self | Allows players to add an enchantment to their own held item. | `/ienchant` | admins |
-| core.gamerule |  | `/gamerule` |  |
+| core.gamerule | Allows players to set and query game rule values | `/gamerule` | admins |
 | core.give | Allows players to give items to other players. | `/give` | admins |
 | core.give.unsafe | Allows players to give items to other players, even if the item is blacklisted. | `/unsafegive` | none |
 | core.help |  | `/help` |  |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Implements some of the basic commands needed to run a simple server.
 # Commands
 
 ### General
-
 | Command | Permission | Description |
 | ------- | ---------- | ----------- |
 |/ban | core.ban | Bans a player.|
@@ -14,6 +13,7 @@ Implements some of the basic commands needed to run a simple server.
 |/effect | core.effect | Adds an effect to a player.|
 |/enchant | core.enchant | Adds an enchantment to a specified player's held item.|
 |/gamemode | core.changegm | Changes a player's gamemode.|
+|/gamerule | core.gamerule | Sets or queries a game rule value.|
 |/give | core.give | Gives an item to a player.|
 |/help | core.help | Shows available commands.|
 |/ienchant | core.enchant.self | Adds an enchantment to an item.|
@@ -24,10 +24,10 @@ Implements some of the basic commands needed to run a simple server.
 |/listranks | core.listranks | Shows a list of the available ranks.|
 |/me | core.me | Broadcasts what you are doing.|
 |/motd | core.motd | Shows the message of the day.|
-|/op | core.rank | Add a player to the administrator rank. |
+|/op | core.rank | Add a player to the administrator rank.|
 |/plugins | core.plugins | Shows a list of the plugins.|
 |/portal | core.portal | Moves your player to a different world.|
-|/r | core.tell | Replies to the latest private message you recieved.|
+|/r | core.tell | Replies to the latest private message you received.|
 |/rank | core.rank | Shows or sets a player's rank.|
 |/regen | core.regen | Regenerates a chunk.|
 |/reload | core.reload | Reloads all plugins.|
@@ -64,7 +64,6 @@ Implements some of the basic commands needed to run a simple server.
 
 
 # Permissions
-
 | Permissions | Description | Commands | Recommended groups |
 | ----------- | ----------- | -------- | ------------------ |
 | core.ban |  | `/ban` |  |
@@ -72,8 +71,10 @@ Implements some of the basic commands needed to run a simple server.
 | core.clear |  | `/clear` |  |
 | core.difficulty |  | `/difficulty` |  |
 | core.do |  | `/do` |  |
+| core.effect |  | `/effect` |  |
 | core.enchant | Allows players to add an enchantment to a player's held item. | `/enchant` | admins |
 | core.enchant.self | Allows players to add an enchantment to their own held item. | `/ienchant` | admins |
+| core.gamerule |  | `/gamerule` |  |
 | core.give | Allows players to give items to other players. | `/give` | admins |
 | core.give.unsafe | Allows players to give items to other players, even if the item is blacklisted. | `/unsafegive` | none |
 | core.help |  | `/help` |  |
@@ -87,7 +88,7 @@ Implements some of the basic commands needed to run a simple server.
 | core.motd |  | `/motd` |  |
 | core.plugins |  | `/plugins` |  |
 | core.portal |  | `/portal` |  |
-| core.rank |  | `/rank`, `/op`, `/deop` |  |
+| core.rank |  | `/rank`, `/deop`, `/op` |  |
 | core.regen |  | `/regen` |  |
 | core.reload |  | `/reload` |  |
 | core.save-all |  | `/save-all` |  |

--- a/gamerule.lua
+++ b/gamerule.lua
@@ -43,8 +43,8 @@ end
 local function HandleSplit(split)
 	local ret = ""
 	if #split == 1 then -- List currently set game rules
-		for rule, value in pairs(GameRules) do
-			ret = ret .. rule .. "="..tostring(value).. ", "
+		for rule in pairs(GameRules) do
+			ret = ret .. rule .. ", "
 		end
 		ret = ret:sub(1, -3)
 		return ret

--- a/gamerule.lua
+++ b/gamerule.lua
@@ -1,0 +1,57 @@
+
+-- gamerule.lua
+
+-- Implements gamerule command and related functions
+
+
+
+-- SQLite DB handler
+local grDB
+
+-- Functions that handle hooks
+
+
+
+-- Initialization functions
+local function InitalizeIni()
+	-- Try to open gamerules.ini and load [Game Rules] and [Types] keys
+	-- Or copy default ini file to server root
+end
+
+local function InitalizeDB()
+	-- Validate GameRule.sqlite or create a new DB
+	local ErrMsg
+	grDB, ErrMsg = NewSQLiteDB("GameRule.sqlite")
+	if not(grDB) then
+		LOGWARNING("Cannot open the Game Rule database, some things may not work right. SQLite: " .. (ErrMsg or "<no details>"))
+		error(ErrMsg)
+	end
+
+	-- Table Structures
+	local tables =
+	{
+		keepInventory =
+		{
+			"Player",
+			"Inventory",
+			"isOnline",
+			"receivedInventory",
+		},
+	}
+	for table, columns in pairs(tables) do
+		if not(grDB:CreateDBTable(table, columns)) then
+			LOGWARNING("Cannot initialize " .. table )
+			error("GameRule DB error: Creating Table " .. table)
+		end
+		
+	end
+
+end
+
+--- Init function to be called upon plugin setup
+function IntializeGameRule()
+	-- Loads gamerules.ini values into GaeRule table, or creates the ini file
+	InitalizeIni()
+
+	-- Register hooks for various game rules
+end

--- a/gamerule.lua
+++ b/gamerule.lua
@@ -118,7 +118,7 @@ local function InitalizeIni()
 	ini:CaseSensitive()
 	local function CopyIni()
 		LOGINFO("Game Rule Settings not found or corrupt! Resetting to default game rules! (This may mess up your game)")
-		cFile:Copy(cPluginManager:GetPluginsPath().."/"..cPluginManager:GetCurrentPlugin():GetFolderName().."/gamerules.ini", "gamerules.ini")
+		cFile:Copy("Plugins/Core/gamerules.ini", "gamerules.ini")
 	end
 	
 	if not(ini:ReadFile("gamerules.ini")) then -- gamerules.ini doesn't exist

--- a/gamerule.lua
+++ b/gamerule.lua
@@ -28,7 +28,7 @@ end
 local function SaveValue(rule, value)
 	if type(value) == boolean then
 		ini:SetValueB("Game Rules", rule, value)
-		ini:SetValue("Types", rule, number)
+		ini:SetValue("Types", rule, boolean)
 	elseif type(value) == number then
 		ini:SetValueI("Game Rules", rule, value)
 		ini:SetValue("Types", rule, number)
@@ -102,6 +102,7 @@ end
 -- Handle Commands
 function HandleGameRuleCommand(split, player)
 	player:SendMessage(HandleSplit(split))
+	return true
 end
 
 function HandleConsoleGameRule(split)

--- a/gamerule.lua
+++ b/gamerule.lua
@@ -7,8 +7,8 @@
 
 -- SQLite DB handler
 local grDB
-
--- Functions that handle hooks
+local ini = cIniFile()
+-- Handle Commands
 
 
 
@@ -16,6 +16,33 @@ local grDB
 local function InitalizeIni()
 	-- Try to open gamerules.ini and load [Game Rules] and [Types] keys
 	-- Or copy default ini file to server root
+	ini:CaseSensitive()
+	local function CopyIni()
+		LOGINFO("Game Rule Settings not found or corrupt! Resetting to default game rules! (This may mess up your game)")
+		cFile:Copy(cPluginManager:GetPluginsPath().."/"..cPluginManager:GetCurrentPlugin():GetFolderName().."/gamerules.ini", "gamerules.ini")
+	end
+	
+	if not(ini:ReadFile("gamerules.ini")) then -- gamerules.ini doesn't exist
+		CopyIni()
+	else
+		numKeys = ini:GetNumValues("Game Rules")
+		if (numKeys ~= ini:GetNumValues("Types")) then
+			-- gamerules.ini is corrupt!
+			CopyIni()
+		end
+		-- Load game rules into GameRules table
+		for rule = 0, numKeys -1 do
+			local name = ini:GetValueName("Game Rules", rule)
+			local valueType = ini:GetValue("Types", name)
+			if valueType == "boolean" then
+				GameRules[name] = ini:GetValueB("Game Rules", name)
+			elseif valueType == "number" then
+				GameRules[name] = ini:GetValueI("Game Rules", name)
+			else -- assume string
+				GameRules[name] = ini:GetValue("Game Rules", name)
+			end			
+		end
+	end
 end
 
 local function InitalizeDB()
@@ -30,12 +57,18 @@ local function InitalizeDB()
 	-- Table Structures
 	local tables =
 	{
+		--[[
+		tableName =
+		{
+			"column TYPE",
+		},
+		]]--
 		keepInventory =
 		{
 			"Player",
 			"Inventory",
-			"isOnline",
-			"receivedInventory",
+			"isOnline BOOLEAN",
+			"receivedInventory BOOLEAN",
 		},
 	}
 	for table, columns in pairs(tables) do
@@ -43,15 +76,14 @@ local function InitalizeDB()
 			LOGWARNING("Cannot initialize " .. table )
 			error("GameRule DB error: Creating Table " .. table)
 		end
-		
 	end
-
 end
 
 --- Init function to be called upon plugin setup
 function IntializeGameRule()
 	-- Loads gamerules.ini values into GaeRule table, or creates the ini file
 	InitalizeIni()
-
+	InitalizeDB()
 	-- Register hooks for various game rules
+	
 end

--- a/main.lua
+++ b/main.lua
@@ -21,7 +21,7 @@ WorldsSpawnProtect = {}
 WorldsWorldLimit = {}
 WorldsWorldDifficulty = {}
 lastsender = {}
-
+GameRules = {}
 
 
 
@@ -68,6 +68,9 @@ function Initialize(Plugin)
 
 	-- Initialize the Item Blacklist (the list of items that cannot be obtained using the give command)
 	IntializeItemBlacklist( Plugin )
+	
+	-- Initialize Game Rules
+	IntializeGameRule()
 
 	-- Add webadmin tabs:
 	Plugin:AddWebTab("Manage Server",   HandleRequest_ManageServer)


### PR DESCRIPTION
`/gamerule` will list all game rules, show the value of a game rule, or set a game rule.

**_This does not implement the actual game rules!_**

Also, there are a few differences between this and the vanilla command.

- Trying to set `spawnRadius` to `hello` or anything other than a number will fail (try it out in vanilla!)
- Tab-completion does not work. I would have to specify the default game rules as subcommands in the Info.lua file, and that would prevent the inclusion of custom game rules.
- There are a few other minor differences, but I've done my best to make it compatible with the vanilla command.

There's a bug that I've found, can reproduce, but can't find a pattern to.
When you try to retrieve a previously set game rule, the plugin cannot recall it in the `GameRules` table, but the rule is visible when you list the game rules. (also, the value is stored)