### PR TITLE
Switch to ScheduleMoveToWorld

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -99,7 +99,7 @@ function TeleportToPlayer( a_SrcPlayer, a_DstPlayerName, a_TellDst )
 		else
 			-- If destination player is not in the same world, move to the correct world
 			if a_SrcPlayer:GetWorld() ~= a_DstPlayerName:GetWorld() then
-				a_SrcPlayer:MoveToWorld( a_DstPlayerName:GetWorld(), true, Vector3d( a_DstPlayerName:GetPosX() + 0.5, a_DstPlayerName:GetPosY(), a_DstPlayerName:GetPosZ() + 0.5 ) )
+				a_SrcPlayer:ScheduleMoveToWorld( a_DstPlayerName:GetWorld(), Vector3d( a_DstPlayerName:GetPosX() + 0.5, a_DstPlayerName:GetPosY(), a_DstPlayerName:GetPosZ() + 0.5 ), false, true )
 			else
 				a_SrcPlayer:TeleportToEntity( a_DstPlayerName )
 			end

--- a/portal-worlds.lua
+++ b/portal-worlds.lua
@@ -7,10 +7,14 @@ function HandlePortalCommand(Split, Player)
 		SendMessage(Player, "Usage: " .. Split[1] .. " [world]")
 		return true
 	end
+	local World = cRoot:Get():GetWorld(Split[2])
 	if (Player:GetWorld():GetName() == Split[2]) then
 		SendMessageFailure( Player, "You are in " .. Split[2] .. "!" )
 		return true
-	elseif( Player:MoveToWorld(Split[2]) == false ) then
+	elseif( World == nil ) then
+		SendMessageFailure( Player, "Could not find world " .. Split[2] .. "!" )
+		return true
+	elseif( Player:ScheduleMoveToWorld(World, Vector3d(World:GetSpawnX(), World:GetSpawnY(), World:GetSpawnZ())) == false ) then
 		SendMessageFailure( Player, "Could not move to world " .. Split[2] .. "!" )
 		return true
 	end

--- a/portal-worlds.lua
+++ b/portal-worlds.lua
@@ -14,7 +14,7 @@ function HandlePortalCommand(Split, Player)
 	elseif( World == nil ) then
 		SendMessageFailure( Player, "Could not find world " .. Split[2] .. "!" )
 		return true
-	elseif( Player:ScheduleMoveToWorld(World, Vector3d(World:GetSpawnX(), World:GetSpawnY(), World:GetSpawnZ())) == false ) then
+	elseif( Player:ScheduleMoveToWorld(World, Vector3d(World:GetSpawnX(), World:GetSpawnY(), World:GetSpawnZ()), false, true) == false ) then
 		SendMessageFailure( Player, "Could not move to world " .. Split[2] .. "!" )
 		return true
 	end


### PR DESCRIPTION
Changes the /portal command and teleport to player function to use ScheduleMoveToWorld (as recommended by documentation, also removes the race condition fixing https://github.com/cuberite/cuberite/issues/3976)

This PR requires https://github.com/cuberite/cuberite/pull/3979 to work.
