### PR TITLE
Add removegroup handler for WebAdmin

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ daniel0916
 Etmix
 Howaner
 isavegas
+iulian3144 (Iulian PAUN)
 jamestait
 jonfabe
 LogicParrot
@@ -26,4 +27,3 @@ Taugeshtu
 tigerw (Tiger Wang)
 tonibm19
 xoft (Mattes Dolak/madmaxoft)
-iulian3144 (Iulian PAUN)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,3 +26,4 @@ Taugeshtu
 tigerw (Tiger Wang)
 tonibm19
 xoft (Mattes Dolak/madmaxoft)
+iulian3144 (Iulian PAUN)

--- a/web_ranks.lua
+++ b/web_ranks.lua
@@ -241,6 +241,31 @@ end
 
 
 
+--- Processes the RemoveGroup page, removing a group from the specified rank and redirecting back to rank's group list
+local function ShowRemoveGroupPage(a_Request)
+	-- Check params:
+	local RankName = a_Request.PostParams["RankName"]
+	local GroupName = a_Request.PostParams["GroupName"]
+	if ((RankName == nil) or (GroupName == nil)) then
+		return HTMLError("Bad request, missing parameters.")
+	end
+
+	-- Remove the group:
+	cRankManager:RemoveGroupFromRank(GroupName, RankName)
+
+	-- Redirect the user:
+	return
+		"<p>Group removed. <a href='/" ..
+		a_Request.Path ..
+		"?subpage=editgroups&RankName=" ..
+		cUrlParser:UrlEncode(RankName) ..
+		"'>Return to list</a>."
+end
+
+
+
+
+
 --- Handles the AddRank subpage.
 -- Displays the HTML form for adding a new rank, processes the input
 local function ShowAddRankPage(a_Request)
@@ -474,6 +499,7 @@ local g_SubpageHandlers =
 {
 	[""]                = ShowMainRanksPage,
 	["addgroup"]        = ShowAddGroupPage,
+	["removegroup"]     = ShowRemoveGroupPage,
 	["addrank"]         = ShowAddRankPage,
 	["addrankproc"]     = ShowAddRankProcessPage,
 	["confirmdel"]      = ShowConfirmDelPage,

--- a/web_ranks.lua
+++ b/web_ranks.lua
@@ -499,7 +499,6 @@ local g_SubpageHandlers =
 {
 	[""]                = ShowMainRanksPage,
 	["addgroup"]        = ShowAddGroupPage,
-	["removegroup"]     = ShowRemoveGroupPage,
 	["addrank"]         = ShowAddRankPage,
 	["addrankproc"]     = ShowAddRankProcessPage,
 	["confirmdel"]      = ShowConfirmDelPage,
@@ -507,6 +506,7 @@ local g_SubpageHandlers =
 	["editdefaultrank"] = ShowEditDefaultRankPage,
 	["editgroups"]      = ShowEditGroupsPage,
 	["editvisuals"]     = ShowEditVisualsPage,
+	["removegroup"]     = ShowRemoveGroupPage,
 	["savevisuals"]     = ShowSaveVisualsPage,
 }
 

--- a/web_ranks.lua
+++ b/web_ranks.lua
@@ -233,7 +233,7 @@ local function ShowAddGroupPage(a_Request)
 		"<p>Group added. <a href='/" ..
 		a_Request.Path ..
 		"?subpage=editgroups&RankName=" ..
-		cWebAdmin:GetURLEncodedString(RankName) ..
+		cUrlParser:UrlEncode(RankName) ..
 		"'>Return to list</a>."
 end
 


### PR DESCRIPTION
Fixes #140.
Another small fix is the replacement of the obsolete method (according to [ManualBindings.cpp:2321](https://github.com/cuberite/cuberite/blob/950aeff/src/Bindings/ManualBindings.cpp#L2321)) `cWebAdmin:GetURLEncodedString()` with `cUrlParser:UrlEncode()`
_EDIT_: It also fixes #146 (duplicate of #140).