### PR TITLE
Add tps command back

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -472,6 +472,13 @@ g_PluginInfo =
 			HelpString = "Teleports your player to another player.",
 		},
 
+		["/tps"] = 
+		{
+			Permission = "core.tps",
+			Handler = HandleTpsCommand,
+			HelpString = "Returns the tps (ticks per second) from the server.",
+		},
+
 		["/unban"] = 
 		{
 			Permission = "core.unban",
@@ -960,6 +967,12 @@ g_PluginInfo =
 		{
 			Handler =  HandleConsoleTeleport,
 			HelpString = "Teleports a player.",
+		},
+
+		["tps"] =
+		{
+			Handler =  HandleConsoleTps,
+			HelpString =  " - Returns the tps (ticks per second) from the server.",
 		},
 
 		["unban"] =

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Implements some of the basic commands needed to run a simple server.
 |/time set | core.time.set | Sets the time to a given value.|
 |/toggledownfall | core.toggledownfall | Toggles the weather between clear skies and rain.|
 |/tp | core.teleport | Teleports your player to another player.|
+|/tps | core.tps | Returns the tps (ticks per second) from the server.|
 |/unban | core.unban | Unbans a player.|
 |/unsafegive | core.give.unsafe | Gives an item to a player, even if the item is blacklisted.|
 |/unsafeitem | core.item.unsafe | Gives your player an item, even if the item is blacklisted.|
@@ -105,6 +106,7 @@ Implements some of the basic commands needed to run a simple server.
 | core.time.query.gametime | Allows players to display how long the world has existed. | `/time query gametime` |  |
 | core.time.set | Allows players to set the time of day. | `/time night`, `/time day`, `/time set`, `/time add` | admins |
 | core.toggledownfall | Allows players to toggle the weather between clear skies and rain. | `/toggledownfall` | admins |
+| core.tps |  | `/tps` |  |
 | core.unban |  | `/unban` |  |
 | core.viewdistance |  | `/viewdistance` |  |
 | core.weather | Allows players to change the weather. | `/weather` | admins |

--- a/main.lua
+++ b/main.lua
@@ -41,6 +41,8 @@ function Initialize(Plugin)
 	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_PLACING_BLOCK,  OnPlayerPlacingBlock)
 	cPluginManager:AddHook(cPluginManager.HOOK_SPAWNING_ENTITY,       OnSpawningEntity)
 	cPluginManager:AddHook(cPluginManager.HOOK_TAKE_DAMAGE,           OnTakeDamage)
+	cPluginManager:AddHook(cPluginManager.HOOK_TICK,                  OnTick)
+	cPluginManager:AddHook(cPluginManager.HOOK_WORLD_TICK,            OnWorldTick)
 
 	-- Bind ingame commands:
 

--- a/tps.lua
+++ b/tps.lua
@@ -1,0 +1,50 @@
+TpsCache = {}
+GlobalTps = {}
+
+function HandleConsoleTps(Split)
+	LOG("Global TPS: " .. GetAverageNum(GlobalTps))
+	for WorldName, WorldTps in pairs(TpsCache) do
+		LOG("World \"" .. WorldName .. "\": " .. GetAverageNum(WorldTps) .. " TPS");
+	end
+	return true
+end
+
+
+function HandleTpsCommand(Split, Player)
+	Player:SendMessageInfo("Global TPS: " .. GetAverageNum(GlobalTps))
+	for WorldName, WorldTps in pairs(TpsCache) do
+		Player:SendMessageInfo("World \"" .. WorldName .. "\": " .. GetAverageNum(WorldTps) .. " TPS");
+	end
+	return true
+end
+
+
+function GetAverageNum(Table)
+	local Sum = 0
+	for i,Num in ipairs(Table) do
+		Sum = Sum + Num
+	end
+	return math.floor(Sum / #Table * 100) / 100
+end
+
+function OnWorldTick(World, TimeDelta)
+	local WorldTps = TpsCache[World:GetName()]
+	if (WorldTps == nil) then
+		WorldTps = {}
+		TpsCache[World:GetName()] = WorldTps
+	end
+
+	if (#WorldTps >= 10) then
+		table.remove(WorldTps, 1)
+	end
+
+	table.insert(WorldTps, 1000 / TimeDelta)
+end
+
+function OnTick(TimeDelta)
+	if (#GlobalTps >= 10) then
+		table.remove(GlobalTps, 1)
+	end
+
+	table.insert(GlobalTps, 1000 / TimeDelta)
+end


### PR DESCRIPTION
The tps command was originally moved to the Essentials plugin a few years ago. However, since people have become more concerned about tps due to poor performance in recent vanilla versions, and Bukkit-based servers provide a tps command out of the box, I think it makes more sense to make the command a part of Core again. Someone in our Discord server was also confused about the absence of the command.