### PR TITLE
Remove version and date

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -6,8 +6,6 @@
 g_PluginInfo = 
 {
 	Name = "Core",
-	Version = "16",
-	Date = "2019-12-04",
 	SourceLocation = "https://github.com/cuberite/Core",
 	Description = [[Implements some of the basic commands needed to run a simple server.]],
 	

--- a/main.lua
+++ b/main.lua
@@ -27,7 +27,6 @@ lastsender = {}
 -- Called by Cuberite on plugin start to initialize the plugin
 function Initialize(Plugin)
 	Plugin:SetName("Core")
-	Plugin:SetVersion(tonumber(g_PluginInfo["Version"]))
 
 	-- Register for all hooks needed
 	cPluginManager:AddHook(cPluginManager.HOOK_BLOCK_SPREAD,          OnBlockSpread)
@@ -88,7 +87,7 @@ function Initialize(Plugin)
 	LoadMOTD()
 
 	WEBLOGINFO("Core is initialized")
-	LOG("Initialised " .. Plugin:GetName() .. " v." .. Plugin:GetVersion())
+	LOG("Initialised " .. Plugin:GetName())
 
 	return true
 end


### PR DESCRIPTION
Nobody wants to update these (the version number was unchanged for 5 years). I don't think it makes much sense to include them in Core, since the plugin is bundled with the server anyway.