### PR TITLE
Validate lower bound for available help pages

### DIFF
--- a/help.lua
+++ b/help.lua
@@ -51,7 +51,7 @@ local function handleHelpPage(a_Player, a_PageNumber, a_Beginning)
 	local firstLine = (a_PageNumber - 1) * g_CommandsPerPage + 1
 	local lastLine = firstLine + g_CommandsPerPage
 	local maxPages = math.ceil(numCommands / g_CommandsPerPage)
-	if (firstLine > numCommands) then
+	if (firstLine > numCommands or firstLine < 0) then
 		a_Player:SendMessageFailure("The requested page is not available. Only pages 1 - " .. maxPages .. " are available.")
 		return true
 	end


### PR DESCRIPTION
`help.lua` did not check lower bound for the range of available help pages. When `/help 0` or `/help -1` is invoked, the server shows an empty help page instead of the expected error message.
This fixes the issue.