### PR TITLE
Fill Command

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,4 +30,5 @@ tigerw (Tiger Wang)
 tonibm19
 tonitch (Debucquoy Anthony)
 xoft (Mattes Dolak/madmaxoft)
+rmilooo
 

--- a/Info.lua
+++ b/Info.lua
@@ -71,6 +71,20 @@ g_PluginInfo =
 				},
 			},
 		},
+		
+		["/fill"] = 
+		{
+			Permission = "core.fill",
+			Handler = HandleFillCommand,
+			HelpString = "Fills a specified area with a given block type.",
+			ParameterCombinations =
+			{
+				{
+					Params = "<x1> <y1> <z1> <x2> <y2> <z2> <blockID>",
+					Help = "Fills the area between the coordinates (x1, y1, z1) and (x2, y2, z2) with the specified block type. Coordinates can use relative notation (e.g., ~1, ~-2).",
+				},
+			},
+		},
 
 		["/give"] = 
 		{

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Implements some of the basic commands needed to run a simple server.
 |/do | core.do | Runs a command as a player.|
 |/effect | core.effect | Adds an effect to a player.|
 |/enchant | core.enchant | Adds an enchantment to a specified player's held item.|
+|/fill | core.fill | Fills a defined region with the specified block type.|
 |/gamemode | core.changegm | Changes a player's gamemode.|
 |/give | core.give | Gives an item to a player.|
 |/help | core.help | Shows available commands.|
@@ -80,6 +81,7 @@ Implements some of the basic commands needed to run a simple server.
 | core.effect |  | `/effect` |  |
 | core.enchant | Allows players to add an enchantment to a player's held item. | `/enchant` | admins |
 | core.enchant.self | Allows players to add an enchantment to their own held item. | `/ienchant` | admins |
+| core.fill | Allows players to fill an area with a specified block type. | `/fill` | admins |
 | core.give | Allows players to give items to other players. | `/give` | admins |
 | core.give.unsafe | Allows players to give items to other players, even if the item is blacklisted. | `/unsafegive` | none |
 | core.help |  | `/help` |  |

--- a/cmd_fill.lua
+++ b/cmd_fill.lua
@@ -1,0 +1,69 @@
+function HandleFillCommand(Split, Player)
+    local Response
+
+    -- Ensure proper arguments: /fill <x1> <y1> <z1> <x2> <y2> <z2> <blockID>
+    if (#Split ~= 8) then
+        Player:SendMessage("Usage: /fill <x1> <y1> <z1> <x2> <y2> <z2> <blockID>")
+        return true
+    end
+
+    -- Parse coordinates with support for relative notation
+    local pos = Player:GetPosition() -- Get the player's current position
+    local x1 = ParseCoordinate(Split[2], pos.x)
+    local y1 = ParseCoordinate(Split[3], pos.y)
+    local z1 = ParseCoordinate(Split[4], pos.z)
+    local x2 = ParseCoordinate(Split[5], pos.x)
+    local y2 = ParseCoordinate(Split[6], pos.y)
+    local z2 = ParseCoordinate(Split[7], pos.z)
+    local blockTypeName = Split[8]:lower()
+
+    -- Check if coordinates are valid
+    if not (x1 and y1 and z1 and x2 and y2 and z2) then
+        Player:SendMessageFailure("Invalid coordinates! Ensure you enter numbers or use valid relative syntax (~).")
+        return true
+    end
+
+    -- Sort coordinates to ensure x1, y1, z1 are the minimum values
+    if x1 > x2 then x1, x2 = x2, x1 end
+    if y1 > y2 then y1, y2 = y2, y1 end
+    if z1 > z2 then z1, z2 = z2, z1 end
+
+    -- Get the player's world
+    local world = Player:GetWorld()
+
+    -- Compute the chunk range
+    local chunkX1, chunkZ1 = math.floor(x1 / 16), math.floor(z1 / 16)
+    local chunkX2, chunkZ2 = math.floor(x2 / 16), math.floor(z2 / 16)
+
+    local chunks = {}
+    for cx = chunkX1, chunkX2 do
+        for cz = chunkZ1, chunkZ2 do
+            table.insert(chunks, {cx, cz})
+        end
+    end
+
+    -- Load the necessary chunks
+    world:ChunkStay(chunks, nil, function()
+        -- Fill the area with the specified block type using vector-based method
+        local i = 0
+        for x = x1, x2 do
+            for y = y1, y2 do
+                for z = z1, z2 do
+                    local pos = Vector3i(x, y, z)
+                    world:SetBlock(pos, blockTypeName, 0)
+                    i = i + 1
+                end
+            end
+        end
+
+        Player:SendMessageSuccess("Filled " .. i .. " blocks with " .. blockTypeName .. ".")
+        LOGINFO("[" .. Player:GetName() .. "]: " .. StripColorCodes("filled " .. i .. " blocks with " .. blockTypeName .. "."))
+    end)
+
+    return true, Response
+end
+
+function HandleConsoleFill(Split)
+    return HandleFillCommand(Split)
+end
+

--- a/cmd_fill.lua
+++ b/cmd_fill.lua
@@ -17,13 +17,20 @@ function HandleFillCommand(Split, Player)
     local z2 = ParseCoordinate(Split[7], pos.z)
     local blockTypeName = Split[8]:lower()
 
-    -- Check if coordinates are valid
+    -- Validate coordinates
     if not (x1 and y1 and z1 and x2 and y2 and z2) then
-        Player:SendMessageFailure("Invalid coordinates! Ensure you enter numbers or use valid relative syntax (~).")
+        Player:SendMessageFailure("Invalid coordinates! Use numbers or valid relative syntax (~).")
         return true
     end
 
-    -- Sort coordinates to ensure x1, y1, z1 are the minimum values
+    -- Verify block ID using BlockStringToType
+    local blockID = BlockStringToType(blockTypeName)
+    if blockID == -1 then
+        Player:SendMessageFailure("Invalid block ID: " .. blockTypeName)
+        return true
+    end
+
+    -- Sort coordinates to ensure correct boundaries
     if x1 > x2 then x1, x2 = x2, x1 end
     if y1 > y2 then y1, y2 = y2, y1 end
     if z1 > z2 then z1, z2 = z2, z1 end
@@ -31,7 +38,7 @@ function HandleFillCommand(Split, Player)
     -- Get the player's world
     local world = Player:GetWorld()
 
-    -- Compute the chunk range
+    -- Compute chunk range
     local chunkX1, chunkZ1 = math.floor(x1 / 16), math.floor(z1 / 16)
     local chunkX2, chunkZ2 = math.floor(x2 / 16), math.floor(z2 / 16)
 
@@ -42,15 +49,14 @@ function HandleFillCommand(Split, Player)
         end
     end
 
-    -- Load the necessary chunks
+    -- Load necessary chunks and perform fill operation
     world:ChunkStay(chunks, nil, function()
-        -- Fill the area with the specified block type using vector-based method
         local i = 0
         for x = x1, x2 do
             for y = y1, y2 do
                 for z = z1, z2 do
                     local pos = Vector3i(x, y, z)
-                    world:SetBlock(pos, blockTypeName, 0)
+                    world:SetBlock(pos, blockID, 0)
                     i = i + 1
                 end
             end
@@ -66,4 +72,3 @@ end
 function HandleConsoleFill(Split)
     return HandleFillCommand(Split)
 end
-

--- a/core_functions.lua
+++ b/core_functions.lua
@@ -1,3 +1,14 @@
+-- Helper function to parse a coordinate with support for relative notation
+function ParseCoordinate(coord, relativeTo)
+    if coord:sub(1, 1) == "~" then
+        local offset = tonumber(coord:sub(2)) or 0
+        return math.floor(relativeTo + offset)
+    else
+        local num = tonumber(coord)
+        return num or 0  -- Return 0 if the coordinate is invalid
+    end
+end
+
 -- Returns the online mode UUID for a player name, if it exists
 -- Otherwise returns an offline UUID
 function GetPlayerUUID(PlayerName)


### PR DESCRIPTION
feat: Add /fill command for block placement

- Implemented the /fill command with the following syntax:
  /fill <x1> <y1> <z1> <x2> <y2> <z2> <blockID>
  
- **Features:**
  - Supports absolute and relative coordinates (~).
  - Validates block IDs using `BlockStringToType()`.
  - Automatically sorts coordinates to ensure correct area filling.
  - Loads relevant chunks before block placement.
  - Sends success or failure messages to the player.

- **Error Handling:**
  - Invalid coordinate parsing prompts a failure message.
  - Block type validation ensures only existing blocks are used.
  - Logs player actions for server monitoring.